### PR TITLE
change logo href to /api/head to avoid 404

### DIFF
--- a/docs_header.html
+++ b/docs_header.html
@@ -22,7 +22,7 @@ $extrastylesheet
 
 <!--BEGIN TITLEAREA-->
 <header id="header">
-  <h1><a href="/">$projectname</a></h1>
+  <h1><a href="/api/head">$projectname</a></h1>
   <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber">$projectnumber</span><!--END PROJECT_NUMBER-->
 
   <!--BEGIN DISABLE_INDEX-->


### PR DESCRIPTION
I changed the logos href to /api/head to avoid the gh pages default 404